### PR TITLE
Fix anchor in TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * [Overview](#overview)
 * [Getting started](#getting-started)
 * [Handling callbacks](#handling-callbacks)
-* [Customizing the SDK](#customising-sdk)
+* [Customizing the SDK](#customizing-the-sdk)
 * [Creating checks](#creating-checks)
 * [User Analytics](#user-analytics)
 * [Going live](#going-live)


### PR DESCRIPTION
Fixed the anchor for "Customizing SDK" section in TOC so users can jump directly to the content.